### PR TITLE
add scew_parser_ignore_insignificant_whitespaces

### DIFF
--- a/scew/parser.c
+++ b/scew/parser.c
@@ -197,6 +197,16 @@ scew_parser_ignore_whitespaces (scew_parser *parser, scew_bool ignore)
   parser->ignore_whitespaces = ignore;
 }
 
+void 
+scew_parser_ignore_insignificant_whitespaces(scew_parser *parser, scew_bool ignore)
+{
+   assert (parser != NULL);
+   parser->ignore_insignificant_whitespaces = ignore;
+   if(ignore) {
+      parser->ignore_whitespaces = SCEW_FALSE;
+   }
+}
+
 
 /* Private */
 
@@ -225,6 +235,7 @@ parser_create_ (scew_bool namespace, XML_Char separator)
     {
       /* Ignore white spaces by default. */
       parser->ignore_whitespaces = SCEW_TRUE;
+      parser->ignore_insignificant_whitespaces = SCEW_FALSE;
 
       /* No load hooks by default. */
       parser->element_hook.hook = NULL;

--- a/scew/parser.h
+++ b/scew/parser.h
@@ -280,6 +280,13 @@ extern SCEW_API void scew_parser_set_tree_hook (scew_parser *parser,
 extern SCEW_API void scew_parser_ignore_whitespaces (scew_parser *parser,
                                                      scew_bool ignore);
 
+/**
+ * Same as scew_parser_ignore_whitespaces but only ignores
+ * insignificant ones. i.e. the spaces between elements. 
+ * @ingroup SCEWParserLoad
+ */
+extern SCEW_API void scew_parser_ignore_insignificant_whitespaces(scew_parser *parser,
+						      scew_bool ignore);
 
 /**
  * @defgroup SCEWParserAcc Accessors

--- a/scew/xparser.c
+++ b/scew/xparser.c
@@ -290,6 +290,26 @@ expat_end_handler_ (void *data, XML_Char const *elem)
         }
     }
 
+  /* Trim the whitespace in mixed nodes if necessary */
+  if(parser->ignore_insignificant_whitespaces && (contents != NULL) && scew_element_count(current) > 1) 
+   {
+      int isEmpty = 1;
+      for(int i =0;i < scew_strlen(contents); i++)
+       {
+         char c = contents[i];
+         if(!scew_isspace(c))
+           {
+             isEmpty = 0;
+             break;
+           }
+       }
+
+      if(isEmpty)
+        {
+          scew_element_free_contents (current);
+        }
+    }
+
   /* Call loaded element hook. */
   if (parser->element_hook.hook != NULL)
     {

--- a/scew/xparser.c
+++ b/scew/xparser.c
@@ -294,7 +294,8 @@ expat_end_handler_ (void *data, XML_Char const *elem)
   if(parser->ignore_insignificant_whitespaces && (contents != NULL) && scew_element_count(current) > 1) 
    {
       int isEmpty = 1;
-      for(int i =0;i < scew_strlen(contents); i++)
+      int i;
+      for(i =0;i < scew_strlen(contents); i++)
        {
          char c = contents[i];
          if(!scew_isspace(c))

--- a/scew/xparser.h
+++ b/scew/xparser.h
@@ -55,6 +55,7 @@ struct scew_parser
   XML_Char *preamble;           /**< Current XML document tree preamble */
   stack_element *stack;         /**< Current parsed element stack */
   scew_bool ignore_whitespaces; /**< Whether to ignore white spaces */
+  scew_bool ignore_insignificant_whitespaces; /**< Whether to insignificant whitespaces */
   scew_bool parsing_started;    /**< Whether we started parsing any
                                    non-space character before a tree
                                    starts (used in streams) */


### PR DESCRIPTION
As discussed here: http://www.oracle.com/technetwork/articles/wang-whitespace-092897.html
Whitespaces are tricky and different applications have different requirements.

We added the possibility to ignore some whitespaces between elements and keeping the other cases, as elements composed only by whitespaces.

Signed-off-by: Felipe Provenzano <felipe.provenzano_ext@softathome.com>